### PR TITLE
Jet module changes to remove dependencies on lfs4

### DIFF
--- a/modulefiles/build.hera.intel.lua
+++ b/modulefiles/build.hera.intel.lua
@@ -1,67 +1,28 @@
 help([[
-Load environment to compile UFS_UTILS on Hera using Intel
+loads UFS Model prerequisites for Hera/Intel
 ]])
 
-cmake_ver=os.getenv("cmake_ver") or "3.16.1"
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.1/envs/unified-env-rocky8/install/modulefiles/Core")
+
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
+load(pathJoin("stack-intel", stack_intel_ver))
+
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+
+cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 load(pathJoin("cmake", cmake_ver))
 
-hpss_ver=os.getenv("hpss_ver") or ""
-load(pathJoin("hpss", hpss_ver))
+load("ufs_common")
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+setenv("PNETCDF","/apps/pnetcdf/1.12.3/intel_2023.2.0-impi")
 
-hpc_ver=os.getenv("hpc_ver") or "1.2.0"
-load(pathJoin("hpc", hpc_ver))
-
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1.2"
-load(pathJoin("hpc-intel", hpc_intel_ver))
-
-impi_ver=os.getenv("impi_ver") or "2022.1.2"
-load(pathJoin("hpc-impi", impi_ver))
-
-bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-load(pathJoin("bacio", bacio_ver))
-
-g2_ver=os.getenv("g2_ver") or "3.4.5"
-load(pathJoin("g2", g2_ver))
-
-ip_ver=os.getenv("ip_ver") or "3.3.3"
-load(pathJoin("ip", ip_ver))
-
-nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
-load(pathJoin("nemsio", nemsio_ver))
-
-sp_ver=os.getenv("sp_ver") or "2.3.3"
-load(pathJoin("sp", sp_ver))
-
-w3nco_ver=os.getenv("w3nco_ver") or "2.4.1"
-load(pathJoin("w3nco", w3nco_ver))
-
-sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
-load(pathJoin("sfcio", sfcio_ver))
-
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
-load(pathJoin("sigio", sigio_ver))
-
-zlib_ver=os.getenv("zlib_ver") or "1.2.11"
-load(pathJoin("zlib", zlib_ver))
-
-png_ver=os.getenv("png_ver") or "1.6.35"
-load(pathJoin("libpng", png_ver))
-
-hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
-load(pathJoin("hdf5", hdf5_ver))
-
-netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-load(pathJoin("netcdf", netcdf_ver))
-
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
+nccmp_ver=os.getenv("nccmp_ver") or "1.9.0.1"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8.2.1b04"
-load(pathJoin("esmf", esmf_ver))
+setenv("CC", "mpiicc")
+setenv("CXX", "mpiicpc")
+setenv("FC", "mpiifort")
+setenv("CMAKE_Platform", "hera.intel")
 
-nco_ver=os.getenv("nco_ver") or "4.9.1"
-load(pathJoin("nco", nco_ver))
-
-whatis("Description: UFS_UTILS build environment")
+whatis("Description: UFS build environment")

--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -9,11 +9,15 @@ load(pathJoin("cmake", cmake_ver))
 
 load(pathJoin("gnu","9.2.0"))
 
+prepend_path("MODULEPATH","/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+load("stack-intel/2021.5.0")
+load("stack-intel-oneapi-mpi/2021.5.1")
 load(pathJoin("intel","2023.2.0"))
 load(pathJoin("impi","2023.2.0"))
 
 load(pathJoin("pnetcdf","1.12.3"))
 load("szip")
+unload("hdf5")
 load(pathJoin("hdf5parallel","1.10.5"))
 load(pathJoin("netcdf-hdf5parallel","4.7.0"))
 
@@ -22,12 +26,8 @@ setenv("PNETCDF","/apps/pnetcdf/1.12.3/intel_2023.2.0-impi")
 prepend_path("LD_LIBRARY_PATH", "/lfs4/NAGAPE/wof/miniconda3_RL/lib")   -- contains the grib2 libraries that are needed for the WPS compile
 prepend_path("CPATH",           "/usr/include/tirpc")                   -- only be important to the WRF build
 
--- # the Jasper environment settings for WPS
-setenv("JASPERLIB", "/lfs4/NAGAPE/wof/miniconda3_RL/lib")
-setenv("JASPERINC", "/lfs4/NAGAPE/wof/miniconda3_RL/lib/include/jasper")
-
 -- # ESMF V8.6 for MPASSIT
-setenv("ESMFMKFILE", "/lfs4/NAGAPE/hpc-wof1/ywang/tools/esmf-8.6.0/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk")
+load("esmf/8.6.0")
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")

--- a/modulefiles/ufs_common.lua
+++ b/modulefiles/ufs_common.lua
@@ -1,0 +1,32 @@
+whatis("Description: UFS build environment common libraries")
+
+help([[Load UFS Model common libraries]])
+
+local ufs_modules = {
+  {["jasper"]          = "2.0.32"},
+  {["zlib"]            = "1.2.13"},
+  {["libpng"]          = "1.6.37"},
+  {["hdf5"]            = "1.14.0"},
+  {["netcdf-c"]        = "4.9.2"},
+  {["netcdf-fortran"]  = "4.6.0"},
+  {["parallelio"]      = "2.5.10"},
+  {["esmf"]            = "8.5.0"},
+  {["fms"]             = "2023.02.01"},
+  {["bacio"]           = "2.4.1"},
+  {["crtm"]            = "2.4.0"},
+  {["g2"]              = "3.4.5"},
+  {["g2tmpl"]          = "1.10.2"},
+  {["ip"]              = "4.3.0"},
+  {["sp"]              = "2.3.3"},
+  {["w3emc"]           = "2.10.0"},
+  {["gftl-shared"]     = "1.6.1"},
+  {["mapl"]            = "2.40.3-esmf-8.5.0"},
+  {["scotch"]          = "7.0.4"},
+}
+
+for i = 1, #ufs_modules do
+  for name, default_version in pairs(ufs_modules[i]) do
+    local env_version_name = string.gsub(name, "-", "_") .. "_ver"
+    load(pathJoin(name, os.getenv(env_version_name) or default_version))
+  end
+end

--- a/program_setup.F90
+++ b/program_setup.F90
@@ -97,7 +97,6 @@
  integer                                :: is, ie, ierr
  
  !Namelist variables that are used to create global variables
- real                                   :: dx,dy
  integer                                :: nx,ny
 
  namelist /config/ grid_file_input_grid, diag_file_input_grid, hist_file_input_grid, &


### PR DESCRIPTION
The module file used for the latter half of HFIP 2024 used this module file after lfs4 end of life.

I'm seeing here that there are several additional changes that result from using hash a8a11f5e from the master branch of the [main repo](https://github.com/LarissaReames-NOAA/MPASSIT). Please advise on how to move forward with this set of changes.