### PR TITLE
Update modulefile and machine-setup.sh for building on WCOSS2.

### DIFF
--- a/machine-setup.sh
+++ b/machine-setup.sh
@@ -111,7 +111,7 @@ elif [[ -d /data/prod ]] ; then
     target=s4
     module purge
 elif [[ -d /lfs/h2 ]] ; then
-   target="wcoss2"
+   target=wcoss2
    module purge
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2

--- a/machine-setup.sh
+++ b/machine-setup.sh
@@ -110,6 +110,9 @@ elif [[ -d /data/prod ]] ; then
     fi
     target=s4
     module purge
+elif [[ -d /lfs/h2 ]] ; then
+   target="wcoss2"
+   module purge
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi

--- a/modulefiles/build.wcoss2.intel.lua
+++ b/modulefiles/build.wcoss2.intel.lua
@@ -2,78 +2,55 @@ help([[
 Load environment to compile UFS_UTILS on WCOSS2
 ]])
 
-cmake_ver=os.getenv("cmake_ver") or "3.20.2"
+prepend_path("MODULEPATH", "/apps/ops/test/spack-stack-1.6.0-nco/envs/nco-intel-19.1.3.304/install/modulefiles/Core")
+
+cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 load(pathJoin("cmake", cmake_ver))
 
-PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
+PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.3.3"
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 
-craype_ver=os.getenv("craype_ver") or "2.7.13"
+craype_ver=os.getenv("craype_ver") or "2.7.17"
 load(pathJoin("craype", craype_ver))
 
 intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-load(pathJoin("intel", intel_ver))
+load(pathJoin("stack-intel", intel_ver))
 
-cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
-load(pathJoin("cray-mpich", cray_mpich_ver))
+cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.9"
+load(pathJoin("stack-cray-mpich", cray_mpich_ver))
 
-
-libjpeg_ver=os.getenv("libjpeg_ver") or "9c"
+libjpeg_ver=os.getenv("libjpeg_ver") or "2.1.0"
 load(pathJoin("libjpeg", libjpeg_ver))
 
-zlib_ver=os.getenv("zlib_ver") or "1.2.11"
+zlib_ver=os.getenv("zlib_ver") or "1.2.13"
 load(pathJoin("zlib", zlib_ver))
 
 libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 load(pathJoin("libpng", libpng_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
 load(pathJoin("hdf5", hdf5_ver))
 
-netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-load(pathJoin("netcdf", netcdf_ver))
+netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
+load(pathJoin("netcdf-c", netcdf_ver))
 
-bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-load(pathJoin("bacio", bacio_ver))
-
-sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
-load(pathJoin("sfcio", sfcio_ver))
-
-w3nco_ver=os.getenv("w3nco_ver") or "2.4.1"
-load(pathJoin("w3nco", w3nco_ver))
-
-nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
-load(pathJoin("nemsio", nemsio_ver))
-
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
-load(pathJoin("sigio", sigio_ver))
-
-sp_ver=os.getenv("sp_ver") or "2.3.3"
+sp_ver=os.getenv("sp_ver") or "2.5.0"
 load(pathJoin("sp", sp_ver))
 
-ip_ver=os.getenv("ip_ver") or "3.3.3"
-load(pathJoin("ip", ip_ver))
-
-g2_ver=os.getenv("g2_ver") or "3.4.5"
-load(pathJoin("g2", g2_ver))
-
 -- for mpiexec command
-cray_pals_ver=os.getenv("cray_pals_ver") or "1.0.12"
+cray_pals_ver=os.getenv("cray_pals_ver") or "1.3.2"
 load(pathJoin("cray-pals", cray_pals_ver))
 
 udunits_ver=os.getenv("udunits_ver") or "2.2.28"
 load(pathJoin("udunits", udunits_ver))
 
-gsl_ver=os.getenv("gsl_ver") or "2.7"
-load(pathJoin("gsl", gsl_ver))
+gsl_ver=os.getenv("gsl_ver") or "0.37.0"
+load(pathJoin("gsl-lite", gsl_ver))
 
-nco_ver=os.getenv("nco_ver") or "4.9.7"
+nco_ver=os.getenv("nco_ver") or "5.0.6"
 load(pathJoin("nco", nco_ver))
 
-setenv("HPC_OPT","/apps/ops/para/libs")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
-esmf_ver=os.getenv("esmf_ver") or "8.2.1b04"
+esmf_ver=os.getenv("esmf_ver") or "8.5.0"
 load(pathJoin("esmf", esmf_ver))
 
 whatis("Description: UFS_UTILS build environment")


### PR DESCRIPTION
We are now working to build and test all of the components of rrfs-workflow (v2) on WCOSS2. This is a quick PR to update `build.wcoss2.intel.lua` to allow for building MPASSIT there. The modules are loaded through `spack-stack-1.6.0` which is currently used throughout rrfs-workflow. The `machine-setup.sh` file is also updated to detect the correct filespace for loading the WCOSS2 modules. 