### PR TITLE
Use Cray-specific compiler options when building on WCOSS2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,9 @@ else
 fi
 
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
-if [[ "$compiler" == "intel" ]]; then
+if [[ "$target" == "wcoss2" ]]; then
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC -DCMAKE_Fortran_COMPILER=ftn"
+elif [[ "$compiler" == "intel" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort"
 elif [[ "$compiler" == "gnu" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran"


### PR DESCRIPTION
In order to run MPASSIT correctly on WCOSS2, we need to compile with the Cray-specific compiler wrapper scripts (`CC`, `cc`, and `ftn`). These wrappers automatically add the appropriate flags and link the necessary libraries for the target environment, including support for MPI. If we use the intel compilers, then MPI is not correctly linked to MPASSIT and the program runs extremely slowly. The change in this PR to build with these Cray-specific compilers allows MPASSIT to run as expected. 
