### PR TITLE
Support for building/running on ursa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,14 @@ option(OPENMP "use OpenMP threading" ON)
 option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
 
 # Set compiler flags.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fp-model precise")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
+  else()
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check bounds -check contiguous -check format -check stack -check shape -check assume -fstack-protector-all -fpe0 -debug -ftrapuv")
+  endif()
   if(APPLE)
     # The linker on macOS does not include `common symbols` by default.
     # Passing the -c flag includes them and fixes an error with undefined symbols.
@@ -36,7 +40,7 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 endif()
 
-if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -traceback")
   set(CMAKE_C_FLAGS_RELEASE "-O2")
   set(CMAKE_C_FLAGS_DEBUG "-O0")
@@ -76,7 +80,7 @@ set(lib_src
 
 set(exe_src mpassit.F90)
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -assume byterecl")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -fdefault-real-8")

--- a/build.sh
+++ b/build.sh
@@ -40,10 +40,12 @@ if [[ "$target" == "wcoss2" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC -DCMAKE_Fortran_COMPILER=ftn"
 elif [[ "$compiler" == "intel" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort"
+elif [[ "$compiler" == "intel-llvm" ]]; then
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_Fortran_COMPILER=ifx"
 elif [[ "$compiler" == "gnu" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran"
 fi
-export debug=true
+export debug=false
 if [[ "${debug}" == "true" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Debug"
 else

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ elif [[ "$compiler" == "intel-llvm" ]]; then
 elif [[ "$compiler" == "gnu" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran"
 fi
-export debug=false
+export debug=true
 if [[ "${debug}" == "true" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Debug"
 else

--- a/modulefiles/build.ursa.intel-llvm.lua
+++ b/modulefiles/build.ursa.intel-llvm.lua
@@ -1,0 +1,17 @@
+help([[
+This module loads libraries for MPASSIT
+]])
+
+whatis([===[Loads libraries for mpassit ]===])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+
+load("stack-oneapi/2024.2.1")
+load("stack-intel-oneapi-mpi/2021.13")
+
+load("cmake/3.30.2")
+load("esmf/8.8.0")
+
+setenv("CMAKE_C_COMPILER", "mpiicx")
+setenv("CMAKE_CXX_COMPILER", "mpiicpx")
+setenv("CMAKE_Fortran_COMPILER", "mpiifx")


### PR DESCRIPTION
This PR provides updated versions of build.sh and CMakeLists.txt, and a new modulefiles/build.ursa.intel-llvm.lua, for building and running MPASSIT on the new NOAA RDHPCS machine _ursa_.

The revised build.sh adds a new intel-llvm compiler target, specifying the icx, icpc, and ifx C, C++, and Fortran compilers, respectively. Although ursa does contain an Intel oneAPI 2023 compiler package with the older icc, icpc, and ifort compilers, it cannot be used because the required esmf package (available through spack-stack) was compiled with the Intel oneAPI 2024 compilers.

The revised CMakeLists.txt adds compiler flags for the Intel LLVM-based Fortran and C compilers. Any LLVM-specific compiler flags are wrapped in an if statement to apply only to the LLVM compilers, such that there are no functional changes to the existing Intel compiler flags.

The new build.ursa.intel-llvm.lua file specifies the module files/environment for building on ursa.

This code has been tested on ursa in both debug and feature mode. It has not yet been tested on other RDHPCS machines. Thanks to Sam Trahan and Eric James for their help in putting this together.