### PR TITLE
Adding some logic to enable building within rrfs-workflow

### DIFF
--- a/machine-setup.sh
+++ b/machine-setup.sh
@@ -16,8 +16,10 @@ else
     __ms_shell=sh
 fi
 
-target=""
+target="${MACHINE}"
 USERNAME=`echo $LOGNAME | awk '{ print tolower($0)'}`
+
+if [[ ${target} == "" ]] ; then
 
 if [[ -d /lfs5 || -d /lfs6 ]] ; then
     # We are on NOAA Jet
@@ -115,6 +117,10 @@ elif [[ -d /lfs/h2 ]] ; then
    module purge
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
+fi
+
+elif [[ ${target} == "ursa" ]] ; then
+   compiler=intel-llvm
 fi
 
 unset __ms_shell

--- a/machine-setup.sh
+++ b/machine-setup.sh
@@ -29,7 +29,7 @@ if [[ -d /lfs5 || -d /lfs6 ]] ; then
     fi
     target=jet
     module purge
-elif [[ -d /scratch1 ]] ; then
+elif [[ -d /scratch3 || -d /scratch4 ]] ; then
     # We are on NOAA Hera
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         echo load the module command 1>&2


### PR DESCRIPTION
Because Hera and Ursa share filesystems, we can't use the directory path to determine the machine upon which we are attempting to build MPASSIT.  For stand-alone builds, we just need to specify machine and compiler when building.  But when building in rrfs-workflow, we need another way to determine what machine we are on.

This PR enables us to use $MACHINE from rrfs-workflow to determine that we are on Ursa.  We also need to set the compiler as intel-llvm if we are on Ursa.

MPASSIT building and running was tested in the rrfs-workflow context on Ursa.  I also confirmed we can still build stand-alone MPASSIT.