### PR TITLE
Use contrib instead of scratch installation of spack-stack.

### DIFF
--- a/modulefiles/build.hera.intel.lua
+++ b/modulefiles/build.hera.intel.lua
@@ -3,7 +3,7 @@ This module loads libraries for MPASSIT
 ]])
 
 whatis([===[Loads libraries for rrfs-workflow ]===])
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
 
 load("stack-intel/2021.5.0")
 load("stack-intel-oneapi-mpi/2021.5.1")


### PR DESCRIPTION
The scratch1 space on Hera was deprecated after yesterday's maintenance. This changes the location of the spack-stack installation to the contrib space with the same version of spack-stack. 