### PR TITLE
For lat-lon projections, update the 'DX' and 'DY' global attributes to be expressed as angular widths (in degrees)

### DIFF
--- a/write_data.F90
+++ b/write_data.F90
@@ -4,7 +4,7 @@ module write_data
     use utils_mod
     use program_setup, only: output_file
     use datetime_module, only: datetime, timedelta, clock
-    use misc_definitions_module, only: PROJ_LC, PROJ_CASSINI
+    use misc_definitions_module, only: PROJ_LC, PROJ_LATLON, PROJ_CASSINI
     private
 
     public :: write_to_file
@@ -26,7 +26,7 @@ contains
         use program_setup, only: interp_diag, interp_hist, &
                                  wrf_mod_vars, truelat1, truelat2, &
                                  stand_lon, proj_code, map_proj_char, &
-                                 i_target, j_target, dxkm, &
+                                 i_target, j_target, dxkm, dlondeg, dlatdeg, &
                                  ref_lat, ref_lon, pole_lat, &
                                  pole_lon, missing_value
 
@@ -184,12 +184,6 @@ contains
             error = nf90_put_att(ncid, NF90_GLOBAL, 'START_DATE', start_time)
             call netcdf_err(error, 'DEFINING START DATE GLOBAL ATTRIBUTE')
 
-            error = nf90_put_att(ncid, NF90_GLOBAL, 'DX', dxkm)
-            call netcdf_err(error, 'DEFINING DX GLOBAL ATTRIBUTE')
-
-            error = nf90_put_att(ncid, NF90_GLOBAL, 'DY', dxkm)
-            call netcdf_err(error, 'DEFINING DY GLOBAL ATTRIBUTE')
-
             error = nf90_put_att(ncid, NF90_GLOBAL, 'DT', config_dt)
             call netcdf_err(error, 'DEFINING DT GLOBAL ATTRIBUTE')
 
@@ -234,6 +228,18 @@ contains
 
             error = nf90_put_att(ncid, NF90_GLOBAL, 'MAP_PROJ_CHAR', map_proj_char)
             call netcdf_err(error, 'DEFINING MAP_PROJ_CHAR GLOBAL ATTRIBUTE')
+
+            if (PROJ_CODE==PROJ_LATLON) then
+               error = nf90_put_att(ncid, NF90_GLOBAL, 'DX', dlondeg)
+               call netcdf_err(error, 'DEFINING DX GLOBAL ATTRIBUTE')
+               error = nf90_put_att(ncid, NF90_GLOBAL, 'DY', dlatdeg)
+               call netcdf_err(error, 'DEFINING DY GLOBAL ATTRIBUTE')
+            else
+               error = nf90_put_att(ncid, NF90_GLOBAL, 'DX', dxkm)
+               call netcdf_err(error, 'DEFINING DX GLOBAL ATTRIBUTE')
+               error = nf90_put_att(ncid, NF90_GLOBAL, 'DY', dxkm)
+               call netcdf_err(error, 'DEFINING DY GLOBAL ATTRIBUTE')
+            end if
 
             if (interp_diag) then
                 error = nf90_put_att(ncid, NF90_GLOBAL, 'PREC_ACC_DT', diag_out_interval)


### PR DESCRIPTION
This PR modifies the formulation of the '**DX'** and '**DY**' global attributes for latitude–longitude projections.  In particular, these attributes are now output by MPASSIT as angular widths (in degrees), rather than distances.  

Prior to this update, downstream processing of MPASSIT-generated netCDF files by the Unified Postprocessor (UPP) would yield dlat/dlon values of zero in the GRIB2 files for lat–lon domains; e.g.,

```
> wgrib2 POSTPRS.GrbF06 -d 1 -V
1:0:vt=2025081206:2 mb:6 hour fcst:HGT Geopotential Height [gpm]:
    ndata=3553778:undef=0:mean=41833.5:min=36933.3:max=43695.4
    grid_template=0:winds(N/S):
	lat-lon grid:(2666 x 1333) units 1e-06 input WE:SN output WE:SN res 48
	lat -89.910004 to 89.910004 by 0.000000
	lon 0.112500 to 359.887512 by 0.000000 #points=3553778
```

This update enables UPP to provide the correct dlat/dlon values (in degrees); e.g.,
```
> wgrib2 POSTPRS.GrbF06.new -d 1 -V
1:0:vt=2025081206:2 mb:6 hour fcst:HGT Geopotential Height [gpm]:
    ndata=3553778:undef=0:mean=41833.5:min=36933.3:max=43695.4
    grid_template=0:winds(N/S):
	lat-lon grid:(2666 x 1333) units 1e-06 input WE:SN output WE:SN res 48
	lat -89.910004 to 89.910004 by 0.135000
	lon 0.112500 to 359.887512 by 0.135000 #points=3553778
```
It has been tested on Jet using a global lat–lon domain.  Thanks to @clark-evans for the suggestions and collaboration.