### PR TITLE
Allow building in debug or release mode.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ elif [[ "$compiler" == "intel-llvm" ]]; then
 elif [[ "$compiler" == "gnu" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran"
 fi
-export debug=${debug:-true}
+
 if [[ "${debug}" == "true" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Debug"
 else

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 
 target=${1:-"NULL"}
 compiler=${2:-"intel"}
-debug=${3:-"false"}
+debug=${3:-"true"}
 
 # If target is not set
 if [[ "$target" == "NULL" ]]; then
@@ -45,7 +45,7 @@ elif [[ "$compiler" == "intel-llvm" ]]; then
 elif [[ "$compiler" == "gnu" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran"
 fi
-export debug=true
+export debug=${debug:-true}
 if [[ "${debug}" == "true" ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Debug"
 else


### PR DESCRIPTION
There's an error in build.sh:

```bash
debug=${3:-"false"}
...
export debug=true
```

The `$debug` flag is hard-coded to `true`, overriding the argument.

This PR passes the debug flag to cmake, while retaining the default value of `true`.

Perhaps the default `$debug` should be changed to default to `false`, but that belongs in a different PR. This PR is intended to be a zero-impact change to those who don't use the `$debug` flag.

EDIT: You can test this like so:

`./build.sh '' '' true` - build in debug mode with other options set to default
`./build.sh '' '' false` - build in release mode with other options set to default