### PR TITLE
read `dz` and `dzs` from history.nc

### DIFF
--- a/input_data.F90
+++ b/input_data.F90
@@ -25,7 +25,7 @@
  use model_grid, only             : input_grid,        &
                                     nCells_input, nVert_input,  &
                                     nz_input, nzp1_input, &
-                                    nsoil_input, strlen, &
+                                    strlen, &
                                     valid_time, config_dt, &
                                     start_time, lsm_scheme, &
                                     mp_scheme, conv_scheme, &
@@ -86,6 +86,14 @@
  implicit none
 
  private
+
+ integer, public                        :: nsoil_input
+                                           !< number of input soil levels
+ real(esmf_kind_r8), allocatable , public :: zs_target_grid(:,:)
+                                          !< soil center depth, target grid
+ real(esmf_kind_r8), allocatable , public :: dzs_target_grid(:,:)
+                                          !< soil layer thickness, target grid
+
  public :: read_input_data
 
  contains
@@ -491,6 +499,35 @@
  if (localpet==0) print*, "- GETTING xtime"
  error = nf90_get_var(ncid, id_var, valid_time)
  call netcdf_err(error, 'getting xtime')
+
+ !Get nSoilLevels size
+ if (localpet==0) print*,'- READ nSoilLevels'
+ error = nf90_inq_dimid(ncid,'nSoilLevels',id_dim)
+ call netcdf_err(error, 'reading nSoilLevels id')
+
+ error=nf90_inquire_dimension(ncid,id_dim,len=nsoil_input)
+ call netcdf_err(error, 'reading nSoilLevels')
+
+ allocate(zs_target_grid(nsoil_input,1))
+ allocate(dzs_target_grid(nsoil_input,1))
+
+ ! SOIL CENTER DEPTHS
+ if (localpet==0) print*,'- READ ZS ID'
+ error=nf90_inq_varid(ncid, 'zs', id_var)
+ call netcdf_err(error, 'reading zs id')
+
+ if (localpet==0) print*,'- READ ZS'
+ error=nf90_get_var(ncid, id_var, start=(/1,1/),count=(/nsoil_input,1/),values=zs_target_grid)
+ call netcdf_err(error, 'reading ZS')
+
+ ! SOIL LAYER THICKNESSES
+ if (localpet==0) print*,'- READ DZS ID'
+ error=nf90_inq_varid(ncid, 'dzs', id_var)
+ call netcdf_err(error, 'reading dzs id')
+
+ if (localpet==0) print*,'- READ DZS'
+ error=nf90_get_var(ncid, id_var, start=(/1,1/),count=(/nsoil_input,1/),values=dzs_target_grid)
+ call netcdf_err(error, 'reading DZS')
 
 !---------------------------------------------------------------------------
 ! Initialize 2d esmf atmospheric fields for bilinear/patch interpolation

--- a/input_data.F90
+++ b/input_data.F90
@@ -429,14 +429,24 @@
  real(esmf_kind_r8), pointer     :: varptr(:), varptr2(:,:)
 
 
- call init_input_hist_fields(localpet)
-
- if (localpet==0) print*,"- READ INPUT HIST DATA."
-
-
  the_file = trim(hist_file_input_grid)
  error=nf90_open(trim(the_file),nf90_nowrite,ncid)
  call netcdf_err(error, 'opening: '//trim(the_file) )
+
+ !nSoilLevels must be read before init_input_hist_fields
+ if (localpet==0) print*,'- READ nSoilLevels'
+ error = nf90_inq_dimid(ncid,'nSoilLevels',id_dim)
+ call netcdf_err(error, 'reading nSoilLevels id')
+
+ error=nf90_inquire_dimension(ncid,id_dim,len=nsoil_input)
+ call netcdf_err(error, 'reading nSoilLevels')
+
+ allocate(zs_target_grid(nsoil_input,1))
+ allocate(dzs_target_grid(nsoil_input,1))
+
+ call init_input_hist_fields(localpet)
+
+ if (localpet==0) print*,"- READ INPUT HIST DATA."
 
 !---------------------------------------------------------------------------
 ! Read global attributes for use when creating output file
@@ -499,17 +509,6 @@
  if (localpet==0) print*, "- GETTING xtime"
  error = nf90_get_var(ncid, id_var, valid_time)
  call netcdf_err(error, 'getting xtime')
-
- !Get nSoilLevels size
- if (localpet==0) print*,'- READ nSoilLevels'
- error = nf90_inq_dimid(ncid,'nSoilLevels',id_dim)
- call netcdf_err(error, 'reading nSoilLevels id')
-
- error=nf90_inquire_dimension(ncid,id_dim,len=nsoil_input)
- call netcdf_err(error, 'reading nSoilLevels')
-
- allocate(zs_target_grid(nsoil_input,1))
- allocate(dzs_target_grid(nsoil_input,1))
 
  ! SOIL CENTER DEPTHS
  if (localpet==0) print*,'- READ ZS ID'

--- a/interp.F90
+++ b/interp.F90
@@ -23,10 +23,11 @@
                                     proj_code, stand_lon, &
                                     missing_value
 
+ use input_data, only             : nsoil_input
+
  use model_grid, only             : input_grid, target_grid, &
                                     nCells_input, nVert_input,  &
                                     nz_input, nzp1_input, &
-                                    nsoil_input, &
                                     cell_latitude_input_grid, &
                                     cell_longitude_input_grid, &
                                     zgrid_input_grid, &

--- a/model_grid.F90
+++ b/model_grid.F90
@@ -27,8 +27,6 @@
                                            !< number of input grid atm layers
  integer, public                        :: nzp1_input
                                            !< number of input grid atm layer interfaces
- integer, public                        :: nsoil_input
-                                           !< number of input soil levels
  !real, public                           :: dx
  !                                          !< grid size (m) of target grid
  character(50), public                  :: start_time
@@ -116,10 +114,6 @@
  type(esmf_field),  public              :: longitude_v_target_grid
                                            !< longitude of grid v stagger, target
                                            !grid
- real(esmf_kind_r8), allocatable , public :: zs_target_grid(:,:)
-                                          !< soil center depth, target grid
- real(esmf_kind_r8), allocatable , public :: dzs_target_grid(:,:)
-                                          !< soil layer thickness, target grid
  type(esmf_field), public               :: hgt_input_grid, hgt_target_grid
                                           !< surface elevation, target grid
  type(esmf_field), public               :: mapfac_m_target_grid
@@ -331,14 +325,6 @@
 
  error=nf90_inquire_dimension(ncid,id_dim,len=maxEdges)
  call netcdf_err(error, 'reading maxEdges')
-
- !Get nSoilLevels size
-  if (localpet==0) print*,'- READ nSoilLevels'
- error = nf90_inq_dimid(ncid,'nSoilLevels',id_dim)
- call netcdf_err(error, 'reading nSoilLevels id')
-
- error=nf90_inquire_dimension(ncid,id_dim,len=nsoil_input)
- call netcdf_err(error, 'reading nSoilLevels')
  
  allocate(latCell(nCells))
  allocate(lonCell(nCells))
@@ -349,8 +335,6 @@
 
  
  allocate(vertOnCell(maxEdges,nCells))
- allocate(zs_target_grid(nsoil_input,1))
- allocate(dzs_target_grid(nsoil_input,1))
 
  ! GET CELL CENTER LAT/LON
  if (localpet==0) print*,'- READ LONCELL ID'
@@ -385,24 +369,6 @@
  if (localpet==0) print*,'- READ LATVERTEX'
  error=nf90_get_var(ncid, id_var,  start=(/1/),count=(/nVertices/),values=latVert)
  call netcdf_err(error, 'reading latVertex')
-
-  ! SOIL CENTER DEPTHS
- if (localpet==0) print*,'- READ ZS ID'
- error=nf90_inq_varid(ncid, 'zs', id_var)
- call netcdf_err(error, 'reading zs id')
-
- if (localpet==0) print*,'- READ ZS'
- error=nf90_get_var(ncid, id_var, start=(/1,1/),count=(/nsoil_input,1/),values=zs_target_grid)
- call netcdf_err(error, 'reading ZS')
-
-  ! SOIL LAYER THICKNESSES
- if (localpet==0) print*,'- READ DZS ID'
- error=nf90_inq_varid(ncid, 'dzs', id_var)
- call netcdf_err(error, 'reading dzs id')
-
- if (localpet==0) print*,'- READ DZS'
- error=nf90_get_var(ncid, id_var, start=(/1,1/),count=(/nsoil_input,1/),values=dzs_target_grid)
- call netcdf_err(error, 'reading DZS')
 
  if (localpet==0) print*,'- READ HGT'
  error=nf90_inq_varid(ncid, 'ter', id_var)

--- a/write_data.F90
+++ b/write_data.F90
@@ -30,10 +30,13 @@ contains
                                  ref_lat, ref_lon, pole_lat, &
                                  pole_lon, missing_value
 
+        use input_data, only: nsoil_input, &
+                              zs_target_grid, &
+                              dzs_target_grid
+
         use model_grid, only: target_grid, &
                               ip1_target, jp1_target, &
                               nz_input, nzp1_input, &
-                              nsoil_input, &
                               start_time, &
                               config_dt, &
                               strlen, valid_time, &
@@ -50,8 +53,6 @@ contains
                               mapfac_v_target_grid, &
                               sina_target_grid, &
                               cosa_target_grid, &
-                              zs_target_grid, &
-                              dzs_target_grid, &
                               hgt_target_grid, &
                               u_target_grid, &
                               v_target_grid, &


### PR DESCRIPTION
`model_grid.F90` reads `dz` and `dzs` but they don't exist in `invariant.nc` files (these two fields are only generated in the process when the LSM gets involved).

This PR allows to read `dz` and `dzs` from `history.nc` files, which is the correct location to get those fields.