### PR TITLE
fix: replace hyphens with equals signs in namelist.input

### DIFF
--- a/parm/namelist.input
+++ b/parm/namelist.input
@@ -1,6 +1,6 @@
-grid_file_input_grid-"/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.init.nc_0325"
+grid_file_input_grid="/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.init.nc_0325"
 hist_file_input_grid="/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.history.2024-03-25_09.00.00.nc"
-diag_file_input_grid-"/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.diag.2024-03-25_09.00.00.nc"
+diag_file_input_grid="/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.diag.2024-03-25_09.00.00.nc"
 block_decomp_file="/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.graph.info.part.120"
 output_file="/1fs4/NAGAPE/hpc-wof1/lreames/mpassit_out.nc"
 interp_diag=.true.


### PR DESCRIPTION
Closes #24

## Summary
Fixes two typos in `parm/namelist.input` where hyphens (`-`) were used instead of equals signs (`=`) as delimiters:

- **Line 1:** `grid_file_input_grid` — replaced `-` with `=`
- **Line 3:** `diag_file_input_grid` — replaced `-` with `=`

## Why
The hyphen characters caused MPASSIT to crash on execution with an error reading the namelist, as Fortran namelist syntax requires `=` as the key-value delimiter.

## Testing
Verified the namelist syntax is correct after the fix.