### PR TITLE
Fix parm/namelist.input

### DIFF
--- a/parm/namelist.input
+++ b/parm/namelist.input
@@ -1,19 +1,21 @@
-grid_file_input_grid-"/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.init.nc_0325"
-hist_file_input_grid="/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.history.2024-03-25_09.00.00.nc"
-diag_file_input_grid-"/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.diag.2024-03-25_09.00.00.nc"
-block_decomp_file="/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.graph.info.part.120"
-output_file="/1fs4/NAGAPE/hpc-wof1/lreames/mpassit_out.nc"
-interp_diag=.true.
-interp_hist=.true.
-wrf_mod_vars=. true.
-esmf_log=. true.
-nx = 1800
-ny = 1060
-dx = 3000.0
-dy = 3000.0
-ref_lat = 38.50
-ref_lon = -97.50
-truelat1 = 38.5
-truelat2 = 38.5
-stand_lon = -97.5
-target_grid_type = 'Lambert'
+&config
+    grid_file_input_grid = "/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.init.nc_0325"
+    hist_file_input_grid = "/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.history.2024-03-25_09.00.00.nc"
+    diag_file_input_grid = "/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.diag.2024-03-25_09.00.00.nc"
+    block_decomp_file    = "/lfs4/NAGAPE/hpc-wof1/reames/MPASSIT/run/mpas.graph.info.part.120"
+    output_file          = "/1fs4/NAGAPE/hpc-wof1/lreames/mpassit_out.nc"
+    interp_diag          = .true.
+    interp_hist          = .true.
+    wrf_mod_vars         = .true.
+    esmf_log             = .true.
+    nx = 1800
+    ny = 1060
+    dx = 3000.0
+    dy = 3000.0
+    ref_lat = 38.50
+    ref_lon = -97.50
+    truelat1 = 38.5
+    truelat2 = 38.5
+    stand_lon = -97.5
+    target_grid_type = 'Lambert'
+/


### PR DESCRIPTION
Fixes typos (- instead of = in lines 1 and 3) in namelist.input, plus adds opening &config block and closing /.

Addresses #24 and supersedes #25.